### PR TITLE
Uses key window for making a snapshot

### DIFF
--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -207,7 +207,7 @@ static CGRect CRGetNotificationContainerFrame(UIInterfaceOrientation statusBarOr
 static UIView *CRStatusBarSnapShotView(BOOL underStatusBar) {
 	if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
 		return underStatusBar ?
-		[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
+		[[UIApplication sharedApplication].keyWindow snapshotViewAfterScreenUpdates:YES] :
 		[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
 	} else {
 		return underStatusBar ?


### PR DESCRIPTION
A minor fix for a problem with an inconsistent transition (Unbalanced calls to begin/end appearance transitions)

**Why did I decide to fork?**
It seems that main repo is not actively maintained. For example, the last changes was made 11 months ago and there are a lot open PRs. So it should be faster to fix in our repo.

**What about fix?**
I think that calling a snapshot API on a view of the rootViewController  wasn't semantically correct because of that view controller hasn't to be on the screen (for example, full screen modal presentation). It makes viewWillAppear being called that can lead to unbalanced calls.